### PR TITLE
ci: Update CD to continuously push to test pypi

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,15 +26,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build sdist and wheel
-        run: pipx run build
-
-      - uses: actions/upload-artifact@v4
-        with:
-          path: dist
-
-      - name: Check products
-        run: pipx run twine check dist/*
+      - uses: hynek/build-and-inspect-python-package@v2
 
   test-built-dist:
     needs: [dist]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,6 @@ name: CD
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main
@@ -15,8 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Many color libraries just need this to be set to any value, but at least
-  # one distinguishes color depth, where "3" -> "256-bit color".
   FORCE_COLOR: 3
 
 jobs:
@@ -29,10 +26,61 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - name: Build sdist and wheel
+        run: pipx run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: dist
+
+      - name: Check products
+        run: pipx run twine check dist/*
+
+  test-built-dist:
+    needs: [dist]
+    name: Test built distribution
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/setup-python@v5.1.1
+        name: Install Python
+        with:
+          python-version: "3.10"
+      - uses: actions/download-artifact@v4
+        with:
+          name: artifact
+          path: dist
+      - name: List contents of built dist
+        run: |
+          ls -ltrh
+          ls -ltrh dist
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.9.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+          skip-existing: true
+      - name: Check pypi packages
+        run: |
+          sleep 3
+          python -m pip install --upgrade pip
+
+          echo "=== Testing wheel file ==="
+          # Install wheel to get dependencies and check import
+          python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade --pre MAWpy
+          python -c "import mawpy; print(mawpy.__version__)"
+          echo "=== Done testing wheel file ==="
+
+          echo "=== Testing source tar file ==="
+          # Install tar gz and check import
+          python -m pip uninstall --yes MAWpy
+          python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade --pre --no-binary=MAWpy MAWpy
+          python -c "import mawpy; print(mawpy.__version__)"
+          echo "=== Done testing source tar file ==="
 
   publish:
-    needs: [dist]
+    needs: [dist, test-built-dist]
     name: Publish to PyPI
     environment: pypi
     permissions:
@@ -43,11 +91,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: Packages
+          name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # Remember to tell (test-)pypi about this repo before publishing
-          # Remove this line to publish to PyPI
-          repository-url: https://test.pypi.org/legacy/
+      - uses: pypa/gh-action-pypi-publish@v1.9.0
+        if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: "3.10"
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: Packages
           path: dist
       - name: List contents of built dist
         run: |
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: Packages
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.9.0


### PR DESCRIPTION
This PR updates the CD to continously push to pypi for every merge to `main`