### PR TITLE
refactor: Streamlined imports to be shorter

### DIFF
--- a/src/mawpy/steps/__init__.py
+++ b/src/mawpy/steps/__init__.py
@@ -1,0 +1,11 @@
+from .address_oscillation import address_oscillation
+from .incremental_clustering import incremental_clustering
+from .trace_segmentation_clustering import trace_segmentation_clustering
+from .update_stay_duration import update_stay_duration
+
+__all__ = [
+    "address_oscillation",
+    "incremental_clustering",
+    "trace_segmentation_clustering",
+    "update_stay_duration"
+]

--- a/src/mawpy/steps/address_oscillation.py
+++ b/src/mawpy/steps/address_oscillation.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from mawpy.constants import USER_ID, UNIX_START_T, STAY_DUR, STAY_LAT, ORIG_LAT, ORIG_LONG, STAY_LONG, AO_COLUMNS
-from mawpy.utilities.preprocessing import get_preprocessed_dataframe, get_list_of_chunks_by_column, execute_parallel
+from ..utilities import get_preprocessed_dataframe, get_list_of_chunks_by_column, execute_parallel
 
 logger = logging.getLogger(__name__)
 

--- a/src/mawpy/steps/incremental_clustering.py
+++ b/src/mawpy/steps/incremental_clustering.py
@@ -19,9 +19,14 @@ from sklearn.cluster import KMeans
 from mawpy.constants import (USER_ID, STAY_DUR, ORIG_LAT, STAY_LAT, STAY_LONG, STAY_UNC, ORIG_LONG, ORIG_UNC, STAY,
                              UNIX_START_T, IC_COLUMNS)
 from mawpy.distance import distance
-from mawpy.utilities.common import get_combined_stay, get_stay_groups
-from mawpy.utilities.cluster import Cluster
-from mawpy.utilities.preprocessing import get_preprocessed_dataframe, get_list_of_chunks_by_column, execute_parallel
+from ..utilities import (
+    Cluster,
+    get_combined_stay,
+    get_stay_groups,
+    get_preprocessed_dataframe,
+    get_list_of_chunks_by_column,
+    execute_parallel
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/mawpy/steps/trace_segmentation_clustering.py
+++ b/src/mawpy/steps/trace_segmentation_clustering.py
@@ -6,8 +6,13 @@ import pandas as pd
 from mawpy.constants import (USER_ID, UNIX_START_DATE, ORIG_LAT, ORIG_LONG, UNIX_START_T,
                              STAY_LAT, STAY_LONG, STAY_DUR, STAY, TSC_COLUMNS)
 from mawpy.distance import distance
-from mawpy.utilities.common import get_combined_stay, get_stay_groups
-from mawpy.utilities.preprocessing import get_preprocessed_dataframe, get_list_of_chunks_by_column, execute_parallel
+from ..utilities import (
+    get_combined_stay,
+    get_stay_groups,
+    get_preprocessed_dataframe,
+    get_list_of_chunks_by_column,
+    execute_parallel
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/mawpy/steps/update_stay_duration.py
+++ b/src/mawpy/steps/update_stay_duration.py
@@ -2,7 +2,11 @@ import logging
 import pandas as pd
 
 from mawpy.constants import UNIX_START_T, USER_ID, STAY_DUR, STAY_LAT, STAY_LONG, STAY_UNC, STAY, UNIX_START_DATE
-from mawpy.utilities.preprocessing import get_preprocessed_dataframe, get_list_of_chunks_by_column, execute_parallel
+from ..utilities import (
+    get_preprocessed_dataframe,
+    get_list_of_chunks_by_column,
+    execute_parallel
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/mawpy/utilities/__init__.py
+++ b/src/mawpy/utilities/__init__.py
@@ -1,0 +1,12 @@
+from .common import get_combined_stay, get_stay_groups
+from .cluster import Cluster
+from .preprocessing import get_preprocessed_dataframe, get_list_of_chunks_by_column, execute_parallel
+
+__all__ = [
+    "get_combined_stay",
+    "get_stay_groups",
+    "Cluster",
+    "get_preprocessed_dataframe",
+    "get_list_of_chunks_by_column",
+    "execute_parallel"
+]

--- a/src/mawpy/workflows/ao_ic_usd.py
+++ b/src/mawpy/workflows/ao_ic_usd.py
@@ -7,9 +7,11 @@ import multiprocessing
 import pandas as pd
 
 from mawpy.constants import AO_IC_USD_WIP_FILE_NAME
-from mawpy.steps.address_oscillation import address_oscillation
-from mawpy.steps.incremental_clustering import incremental_clustering
-from mawpy.steps.update_stay_duration import update_stay_duration
+from mawpy.steps import (
+    address_oscillation,
+    incremental_clustering,
+    update_stay_duration
+)
 import os
 
 import argparse

--- a/src/mawpy/workflows/ic_usd.py
+++ b/src/mawpy/workflows/ic_usd.py
@@ -7,8 +7,10 @@ import multiprocessing
 import pandas as pd
 
 from mawpy.constants import IC_USD_WIP_FILE_NAME
-from mawpy.steps.incremental_clustering import incremental_clustering
-from mawpy.steps.update_stay_duration import update_stay_duration
+from mawpy.steps import (
+    incremental_clustering,
+    update_stay_duration
+)
 import os
 
 import argparse

--- a/src/mawpy/workflows/ic_usd_ao_usd.py
+++ b/src/mawpy/workflows/ic_usd_ao_usd.py
@@ -7,9 +7,11 @@ import multiprocessing
 import pandas as pd
 
 from mawpy.constants import IC_USD_AO_USD_WIP_FILE_NAME
-from mawpy.steps.address_oscillation import address_oscillation
-from mawpy.steps.incremental_clustering import incremental_clustering
-from mawpy.steps.update_stay_duration import update_stay_duration
+from mawpy.steps import (
+    address_oscillation,
+    incremental_clustering,
+    update_stay_duration
+)
 import os
 
 import argparse

--- a/src/mawpy/workflows/tsc_ic_usd.py
+++ b/src/mawpy/workflows/tsc_ic_usd.py
@@ -7,9 +7,11 @@ import multiprocessing
 import pandas as pd
 
 from mawpy.constants import TSC_IC_USD_WIP_FILE_NAME
-from mawpy.steps.incremental_clustering import incremental_clustering
-from mawpy.steps.trace_segmentation_clustering import trace_segmentation_clustering
-from mawpy.steps.update_stay_duration import update_stay_duration
+from mawpy.steps import (
+    trace_segmentation_clustering,
+    incremental_clustering,
+    update_stay_duration
+)
 import os
 
 import argparse

--- a/src/mawpy/workflows/tsc_usd.py
+++ b/src/mawpy/workflows/tsc_usd.py
@@ -7,8 +7,10 @@ import multiprocessing
 import pandas as pd
 
 from mawpy.constants import TSC_USD_WIP_FILE_NAME
-from mawpy.steps.trace_segmentation_clustering import trace_segmentation_clustering
-from mawpy.steps.update_stay_duration import update_stay_duration
+from mawpy.steps import (
+    trace_segmentation_clustering,
+    update_stay_duration
+)
 import os
 
 import argparse


### PR DESCRIPTION
This PR streamlines the imports for `utilities` and `steps` module, so it's not so long and also, only the important functions are visible for the module.